### PR TITLE
Workflow creates an issue for the monthly report

### DIFF
--- a/.github/workflows/monthly-report-issue.yml
+++ b/.github/workflows/monthly-report-issue.yml
@@ -21,10 +21,11 @@ jobs:
       - id: create_issue
         uses: imjohnbo/issue-bot@v3
         with:
+          assignees: AnthonyRollins
           labels: reporting
           title: Customer Success ${{steps.set_output.outputs.month}} Monthly Report
           body: |
-            [${{steps.set_output.outputs.month}} Report](#)
+            [${{steps.set_output.outputs.month}} Report](https://docs.google.com/presentation/d/1lhhYUdt4KoLNO6TzuSN-lWwv3sgOBMoc_drhXgCChGY/copy)
 
             ## To-Do
 

--- a/.github/workflows/monthly-report-issue.yml
+++ b/.github/workflows/monthly-report-issue.yml
@@ -1,0 +1,35 @@
+name: Create Monthly Report issue
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 16:16 UTC on the 2nd of every month
+    - cron: 16 16 2 * *
+
+jobs:
+  create-monthly-report-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      # Get last month's name as a variable
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+      - id: set_output
+        run: |
+          echo "month=$(date -d 'last month' +%B)" >> $GITHUB_OUTPUT
+
+      - id: create_issue
+        uses: imjohnbo/issue-bot@v3
+        with:
+          labels: reporting
+          title: Customer Success ${{steps.set_output.outputs.month}} Monthly Report
+          body: |
+            [${{steps.set_output.outputs.month}} Report](#)
+
+            ## To-Do
+
+            - [ ] Update metrics for ${{steps.set_output.outputs.month}}
+          pinned: false
+          close-previous: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates a Workflow that runs on the 2nd of each month, which will create an issue for tracking completion of the _prior_ month's Customer Success Monthly Report.

The issue will be initially assigned to @AnthonyRollins and the template is as follows:

```md
[(Month Name) Report](https://docs.google.com/presentation/d/1lhhYUdt4KoLNO6TzuSN-lWwv3sgOBMoc_drhXgCChGY/copy)

## To-Do

- [ ] Update metrics for (Month Name)
```

Feel free to request any changes in comments here in the Pull Request.