### PR TITLE
CI: use a custom PAT github token

### DIFF
--- a/.github/workflows/notes-sync.yml
+++ b/.github/workflows/notes-sync.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           LAST_NOTE_ID: ${{steps.download.outputs.last_note_id}}
         with:
+          github-token: ${{ secrets.GH_TOKEN_REPO_VARS }}
           script: |
             const { LAST_NOTE_ID } = process.env;
 

--- a/.github/workflows/notes-sync.yml
+++ b/.github/workflows/notes-sync.yml
@@ -22,8 +22,8 @@ on:
         type: string
         required: false
   schedule:
-    # every hour at HH:35
-    - cron: 35 * * * *
+    # every hour at HH:55
+    - cron: 55 * * * *
 
 jobs:
   sync-notes-to-slack:


### PR DESCRIPTION
Truly the last follow up for #497.

This API call needs permission `"Variables" repository permissions (write)`: https://docs.github.com/en/rest/actions/variables?apiVersion=2022-11-28#update-a-repository-variable
