### PR TITLE
Fix: avoid re-processing duplicate notes

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     image: cal-itp/customer-success:dev
     entrypoint: []
+    env_file: .env
     command: sleep infinity
     ports:
       - "8000"

--- a/notes/__init__.py
+++ b/notes/__init__.py
@@ -1,4 +1,7 @@
+import logging
 from pathlib import Path
+import sys
 
+logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(asctime)s [%(levelname)s] (%(name)s): %(message)s")
 
 NOTES_PATH = Path("data/notes.json")


### PR DESCRIPTION
Hubspot's API seems to be giving us back the record indicated in the `after` parameter (like an "inclusive after" :roll_eyes:).

This PR adds a filter to ensure records with an ID matching `last_note_id` are dropped in pre-processing.

Also added some logging to help with debugging.