### PR TITLE
Product launch table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ This repo aims to track all tasks related to Customer Success. You can find all 
 | [Outreach Campaign Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=communications&projects=&template=outreach-campaign-request.yml&title=%5BOutreach+Campaign+Request%5D%3A+) | Request the Customer Success team conduct an outreach campaign on a specific subject matter
 | [Batch Email Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=email&projects=&template=batch-email-requests.yml&title=%5BBatch+Email%5D:+) | Request the Customer Success team to send out a batch email to transit agencies or vendors
 
+## Product Adoption
+
+| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt |
+| --------------------------------------------------- | -------- | -------- | ----- | ------- |
+| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      |
+| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      |
+| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      |
+| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      |
+| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      |
+| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      |
+| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      |
+| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      |
+| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      |
+| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      |
+| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*    | \*     |
+| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      |
+
 ## Resources
 
 ### Customer Success Resources

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ This repo aims to track all tasks related to Customer Success. You can find all 
 
 ## Cal-ITP Product Adoption
 
-Below is the full list of all agencies live, ineligible, and upcoming across all Cal-ITP Products. Currently there are four Cal-ITP products, Open loop payments, Cal-ITP Benefits, GTFS Planning and Scheduling (Remix) and GTFS-rt. For additional details on each products, go to [Mobility Marketplace](https://www.camobilitymarketplace.org/)
+Below is the full list of all agencies live, ineligible, and upcoming across all Cal-ITP Products. Currently there are four Cal-ITP products, Open loop payments, Cal-ITP Benefits, GTFS Planning and Scheduling (Remix) and GTFS Realtime (GTFS-RT). For additional details on each products, go to [California Mobility Marketplace](https://www.camobilitymarketplace.org/)
+
+### Product definitions
+
+><br>**Open loop payments**: Contactless payments allows riders to pay for transit by simply tapping their contactless bank card or smart device.<br><br>
+**Benefits**: Cal-ITP Benefits connects a rider’s reduced fare to their contactless credit/debit card so that they can get their reduced fare when they tap to ride.<br><br>
+**Remix**: Route planning and scheduling helps streamline transit operations and provide a better transit rider experience through accessible Remix software procurement and access.<br><br>
+**GTFS-RT**: GTFS-RT allows agencies to provide transit riders with real-time vehicle arrival information.<br><br>
 
 ### Table Options
 
@@ -32,97 +39,87 @@ Below is the full list of all agencies live, ineligible, and upcoming across all
 | ❌           | Denotes agencies ineligble to receive Cal-ITP Benetfits, as the provider doesn't offer a discount program |
 | `non-MSA`      | Denotes agencies that did not use the State of California Master Service Agreement (MSA) for tap to pay. |
 
-### Product definitions
+Last updated: `3/09/2026`
 
-**Open loop payments**: Contactless payments allows riders to pay for transit by simply tapping their contactless bank card or smart device.<br><br>
-**Benefits**: Cal-ITP Benefits connects a rider’s reduced fare to their contactless credit/debit card so that they can get their reduced fare when they tap to ride<br><br>
-**Remix**: Route planning and scheduling helps streamline transit operations and provide a better transit rider experience through accessible Remix software procurement and access.<br><br>
-**GTFS-rt**: GTFS Realtime allows agencies to provide transit riders with real-time vehicle arrival information.<br>
-
-Last updated: `3/02/2026`
-
-| Transit provider                                                              | Open loop payments | Benefits | Remix | GTFS-rt |
-| ----------------------------------------------------------------------------- | ------------------ | -------- | ----- | ------- |
-| **Alameda-Contra Costa Transit District (AC Transit)**                        | ✅                 | ✅       | ✅    | \-      |
-| **Calaveras Transit Agency**                                                  | ✅                 | ✅       | ✅    | \-      |
-| **Central Contra Costa Transit Authority (County Connection)**                | ✅                 | ✅       | ✅    | \-      |
-| **City and County of San Francisco**                                          | ✅ (non-MSA)       | ✅       | ✅    | \-      |
-| **City of Arvin**                                                             | ✅                 | ✅       | ✅    | \-      |
-| **City of Camarillo**                                                         | ✅                 | ✅       | ✅    | \-      |
-| **City of Santa Maria**                                                       | ✅                 | ✅       | ✅    | \-      |
-| **Cloverdale Transit**                                                        | ✅                 | ✅       | ✅    | \-      |
-| **Lassen Transit Service Agency**                                             | ✅                 | ✅       | ✅    | \-      |
-| **Siskiyou County Transportation Agency**                                     | \*                 | \*       | \*    | \*      |
-| **Central Contra Costa Transit Authority (County Connection)**                | \*                 | \*       | \*    | \*      |
-| **Glenn County Transportation Commission**                                    | ✅                 | ✅       | ✅    | \*      |
-| **El Dorado Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
-| **City of Escalon**                                                           | ✅                 | ✅       | ✅    | \*      |
-| **City of Fairfield**                                                         | ✅                 | ✅       | ✅    | \*      |
-| **City of Glendale**                                                          | ✅                 | ✅       | ✅    | \*      |
-| **City of Moorpark**                                                          | ✅                 | ✅       | ✅    | \*      |
-| **City of Ojai**                                                              | ✅                 | ✅       | ✅    | \*      |
-| **City of Petaluma**                                                          | ✅                 | ✅       | ✅    | \*      |
-| **City of Roseville**                                                         | ✅                 | ✅       | ✅    | \*      |
-| **City of San Luis Obispo**                                                   | ✅                 | ✅       | ✅    | \*      |
-| **City of Santa Maria**                                                       | ✅                 | ✅       | ✅    | \*      |
-| **City of Santa Rosa**                                                        | ✅                 | ✅       | ✅    | \*      |
-| **City of Simi Valley**                                                       | ✅                 | ✅       | ✅    | \*      |
-| **City of Thousand Oaks**                                                     | ✅                 | ✅       | ✅    | \*      |
-| **City of Union City**                                                        | ✅                 | ✅       | ✅    | \*      |
-| **City of Vacaville**                                                         | ✅                 | ✅       | ✅    | \*      |
-| **Cloverdale Transit**                                                        | ✅                 | ✅       | ✅    | \*      |
-| **County of Kern**                                                            | ✅                 | ✅       | ✅    | \*      |
-| **County of Nevada**                                                          | ✅                 | ✅       | ✅    | \*      |
-| **County of Sacramento (SCT Link)**                                           | ✅                 | ✅       | ✅    | \*      |
-| **Eastern Contra Costa Transit Authority**                                    | ✅                 | ✅       | ✅    | \*      |
-| **El Dorado Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
-| **Glenn County Transportation Commission**                                    | ✅                 | ✅       | ✅    | \*      |
-| **Gold Coast Transit District**                                               | ✅                 | ✅       | ✅    | \*      |
-| **Golden Empire Transit District**                                            | ✅                 | ✅       | ✅    | \*      |
-| **Golden Gate Bridge, Highway & Transportation District**                     | ✅                 | ✅       | ✅    | \*      |
-| **Humboldt Transit Authority**                                                | ✅                 | ✅       | ✅    | \*      |
-| **Imperial County Transportation Commission**                                 | ✅                 | ✅       | ✅    | \*      |
-| **Kings County Area Public Transit Agency**                                   | ✅                 | ✅       | ✅    | \*      |
-| **Lake Transit Authority**                                                    | ✅                 | ✅       | ✅    | \*      |
-| **Lassen Transit Service Agency**                                             | ✅                 | ✅       | ✅    | \*      |
-| **Livermore Amador Valley Transit Authority**                                 | ✅                 | ✅       | ✅    | \*      |
-| **Marin Transit**                                                             | ✅                 | ✅       | ✅    | \*      |
-| **Mendocino Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
-| **Metrolink**                                                                 | ✅                 | ✅       | ✅    | \*      |
-| **Monterey-Salinas Transit**                                                  | ✅                 | ✅       | ✅    | \*      |
-| **Napa Valley Transportation Authority (NVTA)**                               | ✅                 | ✅       | ✅    | \*      |
-| **North County Transit District (NCTD)**                                      | ✅                 | ✅       | ✅    | \*      |
-| **Orange County Transportation Authority**                                    | ✅                 | ✅       | ✅    | \*      |
-| **Placer County**                                                             | ✅                 | ✅       | ✅    | \*      |
-| **Redding Area Bus Authority**                                                | ✅                 | ✅       | ✅    | \*      |
-| **Redwood Coast Transit Authority**                                           | ✅                 | ✅       | ✅    | \*      |
-| **Sacramento Regional Transit District (SacRT)**                              | ✅                 | ✅       | ✅    | \*      |
-| **San Benito County Local Transportation Authority**                          | ✅                 | ✅       | ✅    | \*      |
-| **San Diego Metropolitan Transit System (MTS)**                               | ✅                 | ✅       | ✅    | \*      |
-| **San Francisco Bay Area Rapid Transit District (BART)**                      | ✅                 | ✅       | ✅    | \*      |
-| **San Francisco Bay Area Water Emergency Transportation Authority (WETA)**    | ✅                 | ✅       | ✅    | \*      |
-| **San Luis Obispo Regional Transit Authority**                                | ✅                 | ✅       | ✅    | \*      |
-| **San Mateo County Transit District**                                         | ✅                 | ✅       | ✅    | \*      |
-| **Santa Barbara County Association of Governments (SBCAG)**                   | ✅                 | ✅       | ✅    | \*      |
-| **Santa Barbara Metropolitan Transit District**                               | ✅                 | ✅       | ✅    | \*      |
-| **Santa Clara Valley Transportation Authority (VTA)**                         | ✅                 | ✅       | ✅    | \*      |
-| **Santa Cruz Metropolitan Transit District (Santa Cruz METRO)**               | ✅                 | ✅       | ✅    | \*      |
-| **Siskiyou County Transportation Agency**                                     | ✅                 | ✅       | ✅    | \*      |
-| **Solano County Transit (SolTrans)**                                          | ✅                 | ✅       | ✅    | \*      |
-| **Sonoma County Transit (SC Transit)**                                        | ✅                 | ✅       | ✅    | \*      |
-| **Sonoma-Marin Area Rail Transit**                                            | ✅                 | ✅       | ✅    | \*      |
-| **South County**                                                              | ✅                 | ✅       | ✅    | \*      |
-| **Stanislaus Regional Transit Authority**                                     | ✅                 | ✅       | ✅    | \*      |
-| **Sunline Transit Agency**                                                    | ✅                 | ✅       | ✅    | \*      |
-| **Transit Joint Powers Authority for Merced County**                          | ✅                 | ✅       | ✅    | \*      |
-| **Trinity County**                                                            | ✅                 | ✅       | ✅    | \*      |
-| **Tuolumne County Transit Agency (TCTA)**                                     | ✅                 | ✅       | ✅    | \*      |
-| **University of California, Davis**                                           | ✅                 | ✅       | ✅    | \*      |
-| **Ventura County Transportation Commission (VCTC)**                           | ✅                 | ✅       | ✅    | \*      |
-| **Western Contra Costa Transit Authority**                                    | ✅                 | ✅       | ✅    | \*      |
-| **Yolo County Transportation District**                                       | ✅                 | ✅       | ✅    | \*      |
-| **Yuba-Sutter Transit Authority**                                             | ✅                 | ✅       | ✅    | \*      |
-| **Yurok Tribe**                                                              | ✅                 | ✅       | ✅    | \*      |
+| Transit provider                                                              | Open loop payments | Cal-ITP Benefits | Remix   | GTFS-RT |
+| ----------------------------------------------------------------------------- | ------------------ | ---------------- | ------- | ------- |
+| **Alameda-Contra Costa Transit District (AC Transit)**                        | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Calaveras Transit Agency**                                                  | \-                 | \-               | \-      | \-      |
+| **Caltrain**                                                                  | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Capitol Corridor Joint Powers Authority (CCJPA)**                           | ✅                 | \-               | \-      | \-      |
+| **Central Contra Costa Transit Authority (County Connection)**                | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City and County of San Francisco**                                          | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Arvin**                                                             | \-                 | \-               | ✅      | \-      |
+| **City of Camarillo**                                                         | ✅                 | Q3 2026          | \-      | \-      |
+| **City of Escalon**                                                           | \-                 | \-               | ✅      | \-      |
+| **City of Fairfield**                                                         | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Glendale**                                                          | Q4 2026            | \-               | \-      | Q4 2026 |
+| **City of Moorpark**                                                          | Q2 2026            | ❌               | \-      | \-      |
+| **City of Morro Bay**                                                         | Q2 2026            | ✅               | \-      | \-      |
+| **City of Ojai**                                                              | Q2 2026            | Q3 2026          | \-      | \-      |
+| **City of Petaluma**                                                          | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Roseville**                                                         | Q2 2026            | Q2 2026          | \-      | \-      |
+| **City of San Luis Obispo**                                                   | Q2 2026            | Q2 2026          | \-      | \-      |
+| **City of Santa Maria**                                                       | \-                 | \-               | ✅      | \-      |
+| **City of Santa Rosa**                                                        | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Simi Valley**                                                       | Q3 2026            | Q3 2026          | \-      | \-      |
+| **City of Thousand Oaks**                                                     | Q3 2026            | Q3 2026          | \-      | \-      |
+| **City of Union City**                                                        | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Vacaville**                                                         | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **City of Wasco**                                                             | 2026               | 2026              | \-     | \-      |
+| **Cloverdale Transit**                                                        | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **County of Kern**                                                            | \-                 | \-               | ✅      | \-      |
+| **County of Los Angeles - Department of Public Works**                        | \-                 | \-               | 2026    | \-      |
+| **County of Nevada**                                                          | ✅                 | ✅               | ✅      | \-      |
+| **County of Sacramento (SCT Link)**                                           | Q3 2026            | Q3 2026          | ✅      | \*      |
+| **Eastern Contra Costa Transit Authority**                                    | ✅ `non-MSA`       | ❌               | ✅      | \-      |
+| **Eastern Sierra Transit Authority**                                          | \-                 | \-               | 2026    | \-      |
+| **El Dorado Transit Authority**                                               | ✅                 | ✅               | Q2 2026 | 2026    |
+| **Glenn County Transportation Commission**                                    | Q2 2026            | \-               | ✅      | \-      |
+| **Gold Coast Transit District**                                               | Q3 2026            | Q3 2026          | \-      | \-      |
+| **Golden Empire Transit District**                                            | Q4 2026            | Q4 2026          | \-      | \-      |
+| **Golden Gate Bridge, Highway & Transportation District**                     | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Humboldt Transit Authority**                                                | ✅                 | ❌               | ✅      | \-      |
+| **Imperial County Transportation Commission**                                 | Q4 2026            | Q4 2026          | \-      | Q1 2026  |
+| **Kings County Area Public Transit Agency**                                   | \-                 | \-               | 2026    | \-      |
+| **Lake Transit Authority**                                                    | ✅                 | \-               | ✅      | \-      |
+| **Lassen Transit Service Agency**                                             | \-                 | \-               | ✅      | \-      |
+| **Livermore Amador Valley Transit Authority**                                 | ✅ `non-MSA`       | ❌               | ✅      | \-      |
+| **Marin Transit**                                                             | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Mendocino Transit Authority**                                               | ✅                 | \-               | ✅      | \-      |
+| **Metrolink**                                                                 | 2026               | \-               | \-      | 2026    |
+| **Monterey-Salinas Transit**                                                  | ✅                 | ✅               | ✅      | \-      |
+| **Napa Valley Transportation Authority (NVTA)**                               | ✅ `non-MSA`       | ❌               | ✅      | \-      |
+| **North County Transit District (NCTD)**                                      | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Orange County Transportation Authority**                                    | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Placer County**                                                             | \-                 | \-               | 2026    | \-      |
+| **Redding Area Bus Authority**                                                | ✅                 | ✅               | ✅      | \-      |
+| **Redwood Coast Transit Authority**                                           | ✅                 | ❌               | ✅      | \-      |
+| **Sacramento Regional Transit District (SacRT)**                              | ✅                 | ✅               | \-      | \-      |
+| **San Benito County Local Transportation Authority**                          | \-                 | \-               | ✅      | \-      |
+| **San Diego Metropolitan Transit System (MTS)**                               | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **San Francisco Bay Area Rapid Transit District (BART)**                      | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **San Francisco Bay Area Water Emergency Transportation Authority (WETA)**    | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **San Luis Obispo Regional Transit Authority**                                | Q2 2026            | ✅               | \-      | \-      |
+| **San Mateo County Transit District**                                         | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Santa Barbara County Association of Governments (SBCAG)**                   | ✅                 | Q3 2026          | ✅      | \-      |
+| **Santa Barbara Metropolitan Transit District**                               | ✅                 | ✅               | \-      | \-      |
+| **Santa Clara Valley Transportation Authority (VTA)**                         | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Santa Cruz Metropolitan Transit District (Santa Cruz METRO)**               | Q2 2026            | Q2 2026          | ✅      | \-      |
+| **Siskiyou County Transportation Agency**                                     | \-                 | \-               | 2026    | \-      |
+| **Solano County Transit (SolTrans)**                                          | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Sonoma County Transit (SC Transit)**                                        | ✅ `non-MSA`       | ❌               | ✅      | \-      |
+| **Sonoma-Marin Area Rail Transit**                                            | ✅ `non-MSA`       | ❌               | \-      | \-      |
+| **Stanislaus Regional Transit Authority**                                     | Q4 2026            | Q4 2026          | ✅      | \-      |
+| **Sunline Transit Agency**                                                    | Q4 2026            | Q4 2026          | ✅      | \-      |
+| **Transit Joint Powers Authority for Merced County**                          | \-                 | \-               | ✅      | \-      |
+| **Trinity County**                                                            | \-                 | \-               | ✅      | Q2 2026 |
+| **Tuolumne County Transit Agency (TCTA)**                                     | \-                 | \-               | ✅      | \-      |
+| **University of California, Davis**                                           | \-                 | \-               | \-      | ✅      |
+| **Ventura County Transportation Commission (VCTC)**                           | ✅                 | ✅               | ✅      | \-      |
+| **Western Contra Costa Transit Authority**                                    | ✅                 | ❌               | \-      | \-      |
+| **Yolo County Transportation District**                                       | Q3 2026            | Q3 2026          | \-      | \-      |
+| **Yuba-Sutter Transit Authority**                                             | Q3 2026            | Q3 2026          | \-      | \-      |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Below is the full list of all agencies live, ineligible, and upcoming across all
 
 ### Product definitions
 
->**Open loop payments**: Fill in<br><br>
-**Benefits**: Fill in<br><br>
-**Remix**: Fill in<br><br>
-**GTFS-rt**: Fill in<br><br>
+**Open loop payments**: Contactless payments allows riders to pay for transit by simply tapping their contactless bank card or smart device.<br><br>
+**Benefits**: Cal-ITP Benefits connects a rider’s reduced fare to their contactless credit/debit card so that they can get their reduced fare when they tap to ride<br><br>
+**Remix**: Route planning and scheduling helps streamline transit operations and provide a better transit rider experience through accessible Remix software procurement and access.<br><br>
+**GTFS-rt**: GTFS Realtime allows agencies to provide transit riders with real-time vehicle arrival information.<br>
 
-Last updated: `2/27/2026`
+Last updated: `3/02/2026`
 
 | Transit provider                                                              | Open loop payments | Benefits | Remix | GTFS-rt |
 | ----------------------------------------------------------------------------- | ------------------ | -------- | ----- | ------- |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Last updated: `3/02/2026`
 | **Western Contra Costa Transit Authority**                                    | ✅                 | ✅       | ✅    | \*      |
 | **Yolo County Transportation District**                                       | ✅                 | ✅       | ✅    | \*      |
 | **Yuba-Sutter Transit Authority**                                             | ✅                 | ✅       | ✅    | \*      |
-| **Yurok Tribe)**                                                              | ✅                 | ✅       | ✅    | \*      |
+| **Yurok Tribe**                                                              | ✅                 | ✅       | ✅    | \*      |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -20,22 +20,109 @@ This repo aims to track all tasks related to Customer Success. You can find all 
 | [Outreach Campaign Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=communications&projects=&template=outreach-campaign-request.yml&title=%5BOutreach+Campaign+Request%5D%3A+) | Request the Customer Success team conduct an outreach campaign on a specific subject matter
 | [Batch Email Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=email&projects=&template=batch-email-requests.yml&title=%5BBatch+Email%5D:+) | Request the Customer Success team to send out a batch email to transit agencies or vendors
 
-## Product Adoption
+## Cal-ITP Product Adoption
 
-| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt |
-| --------------------------------------------------- | -------- | -------- | ----- | ------- |
-| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      |
-| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      |
-| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      |
-| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      |
-| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      |
-| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      |
-| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      |
-| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      |
-| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      |
-| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      |
-| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*    | \*     |
-| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      |
+Below is the full list of all agencies live, ineligible, and upcoming across all Cal-ITP Products. Currently there are four Cal-ITP products, Open loop payments, Cal-ITP Benefits, GTFS Planning and Scheduling (Remix) and GTFS-rt. For additional details on each products, go to [Mobility Marketplace](https://www.camobilitymarketplace.org/)
+
+### Table Options
+
+| Option | Description |
+| ------------ | ----------- |
+| ✅           | Denotes agencies live with that product |
+| ❌           | Denotes agencies ineligble to receive Cal-ITP Benetfits, as the provider doesn't offer a discount program |
+| `non-MSA`      | Denotes agencies that did not use the State of California Master Service Agreement (MSA) for tap to pay. |
+
+### Product definitions
+
+>**Open loop payments**: Fill in<br><br>
+**Benefits**: Fill in<br><br>
+**Remix**: Fill in<br><br>
+**GTFS-rt**: Fill in<br><br>
+
+Last updated: `2/27/2026`
+
+| Transit provider                                                              | Open loop payments | Benefits | Remix | GTFS-rt |
+| ----------------------------------------------------------------------------- | ------------------ | -------- | ----- | ------- |
+| **Alameda-Contra Costa Transit District (AC Transit)**                        | ✅                 | ✅       | ✅    | \-      |
+| **Calaveras Transit Agency**                                                  | ✅                 | ✅       | ✅    | \-      |
+| **Central Contra Costa Transit Authority (County Connection)**                | ✅                 | ✅       | ✅    | \-      |
+| **City and County of San Francisco**                                          | ✅ (non-MSA)       | ✅       | ✅    | \-      |
+| **City of Arvin**                                                             | ✅                 | ✅       | ✅    | \-      |
+| **City of Camarillo**                                                         | ✅                 | ✅       | ✅    | \-      |
+| **City of Santa Maria**                                                       | ✅                 | ✅       | ✅    | \-      |
+| **Cloverdale Transit**                                                        | ✅                 | ✅       | ✅    | \-      |
+| **Lassen Transit Service Agency**                                             | ✅                 | ✅       | ✅    | \-      |
+| **Siskiyou County Transportation Agency**                                     | \*                 | \*       | \*    | \*      |
+| **Central Contra Costa Transit Authority (County Connection)**                | \*                 | \*       | \*    | \*      |
+| **Glenn County Transportation Commission**                                    | ✅                 | ✅       | ✅    | \*      |
+| **El Dorado Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
+| **City of Escalon**                                                           | ✅                 | ✅       | ✅    | \*      |
+| **City of Fairfield**                                                         | ✅                 | ✅       | ✅    | \*      |
+| **City of Glendale**                                                          | ✅                 | ✅       | ✅    | \*      |
+| **City of Moorpark**                                                          | ✅                 | ✅       | ✅    | \*      |
+| **City of Ojai**                                                              | ✅                 | ✅       | ✅    | \*      |
+| **City of Petaluma**                                                          | ✅                 | ✅       | ✅    | \*      |
+| **City of Roseville**                                                         | ✅                 | ✅       | ✅    | \*      |
+| **City of San Luis Obispo**                                                   | ✅                 | ✅       | ✅    | \*      |
+| **City of Santa Maria**                                                       | ✅                 | ✅       | ✅    | \*      |
+| **City of Santa Rosa**                                                        | ✅                 | ✅       | ✅    | \*      |
+| **City of Simi Valley**                                                       | ✅                 | ✅       | ✅    | \*      |
+| **City of Thousand Oaks**                                                     | ✅                 | ✅       | ✅    | \*      |
+| **City of Union City**                                                        | ✅                 | ✅       | ✅    | \*      |
+| **City of Vacaville**                                                         | ✅                 | ✅       | ✅    | \*      |
+| **Cloverdale Transit**                                                        | ✅                 | ✅       | ✅    | \*      |
+| **County of Kern**                                                            | ✅                 | ✅       | ✅    | \*      |
+| **County of Nevada**                                                          | ✅                 | ✅       | ✅    | \*      |
+| **County of Sacramento (SCT Link)**                                           | ✅                 | ✅       | ✅    | \*      |
+| **Eastern Contra Costa Transit Authority**                                    | ✅                 | ✅       | ✅    | \*      |
+| **El Dorado Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
+| **Glenn County Transportation Commission**                                    | ✅                 | ✅       | ✅    | \*      |
+| **Gold Coast Transit District**                                               | ✅                 | ✅       | ✅    | \*      |
+| **Golden Empire Transit District**                                            | ✅                 | ✅       | ✅    | \*      |
+| **Golden Gate Bridge, Highway & Transportation District**                     | ✅                 | ✅       | ✅    | \*      |
+| **Humboldt Transit Authority**                                                | ✅                 | ✅       | ✅    | \*      |
+| **Imperial County Transportation Commission**                                 | ✅                 | ✅       | ✅    | \*      |
+| **Kings County Area Public Transit Agency**                                   | ✅                 | ✅       | ✅    | \*      |
+| **Lake Transit Authority**                                                    | ✅                 | ✅       | ✅    | \*      |
+| **Lassen Transit Service Agency**                                             | ✅                 | ✅       | ✅    | \*      |
+| **Livermore Amador Valley Transit Authority**                                 | ✅                 | ✅       | ✅    | \*      |
+| **Marin Transit**                                                             | ✅                 | ✅       | ✅    | \*      |
+| **Mendocino Transit Authority**                                               | ✅                 | ✅       | ✅    | \*      |
+| **Metrolink**                                                                 | ✅                 | ✅       | ✅    | \*      |
+| **Monterey-Salinas Transit**                                                  | ✅                 | ✅       | ✅    | \*      |
+| **Napa Valley Transportation Authority (NVTA)**                               | ✅                 | ✅       | ✅    | \*      |
+| **North County Transit District (NCTD)**                                      | ✅                 | ✅       | ✅    | \*      |
+| **Orange County Transportation Authority**                                    | ✅                 | ✅       | ✅    | \*      |
+| **Placer County**                                                             | ✅                 | ✅       | ✅    | \*      |
+| **Redding Area Bus Authority**                                                | ✅                 | ✅       | ✅    | \*      |
+| **Redwood Coast Transit Authority**                                           | ✅                 | ✅       | ✅    | \*      |
+| **Sacramento Regional Transit District (SacRT)**                              | ✅                 | ✅       | ✅    | \*      |
+| **San Benito County Local Transportation Authority**                          | ✅                 | ✅       | ✅    | \*      |
+| **San Diego Metropolitan Transit System (MTS)**                               | ✅                 | ✅       | ✅    | \*      |
+| **San Francisco Bay Area Rapid Transit District (BART)**                      | ✅                 | ✅       | ✅    | \*      |
+| **San Francisco Bay Area Water Emergency Transportation Authority (WETA)**    | ✅                 | ✅       | ✅    | \*      |
+| **San Luis Obispo Regional Transit Authority**                                | ✅                 | ✅       | ✅    | \*      |
+| **San Mateo County Transit District**                                         | ✅                 | ✅       | ✅    | \*      |
+| **Santa Barbara County Association of Governments (SBCAG)**                   | ✅                 | ✅       | ✅    | \*      |
+| **Santa Barbara Metropolitan Transit District**                               | ✅                 | ✅       | ✅    | \*      |
+| **Santa Clara Valley Transportation Authority (VTA)**                         | ✅                 | ✅       | ✅    | \*      |
+| **Santa Cruz Metropolitan Transit District (Santa Cruz METRO)**               | ✅                 | ✅       | ✅    | \*      |
+| **Siskiyou County Transportation Agency**                                     | ✅                 | ✅       | ✅    | \*      |
+| **Solano County Transit (SolTrans)**                                          | ✅                 | ✅       | ✅    | \*      |
+| **Sonoma County Transit (SC Transit)**                                        | ✅                 | ✅       | ✅    | \*      |
+| **Sonoma-Marin Area Rail Transit**                                            | ✅                 | ✅       | ✅    | \*      |
+| **South County**                                                              | ✅                 | ✅       | ✅    | \*      |
+| **Stanislaus Regional Transit Authority**                                     | ✅                 | ✅       | ✅    | \*      |
+| **Sunline Transit Agency**                                                    | ✅                 | ✅       | ✅    | \*      |
+| **Transit Joint Powers Authority for Merced County**                          | ✅                 | ✅       | ✅    | \*      |
+| **Trinity County**                                                            | ✅                 | ✅       | ✅    | \*      |
+| **Tuolumne County Transit Agency (TCTA)**                                     | ✅                 | ✅       | ✅    | \*      |
+| **University of California, Davis**                                           | ✅                 | ✅       | ✅    | \*      |
+| **Ventura County Transportation Commission (VCTC)**                           | ✅                 | ✅       | ✅    | \*      |
+| **Western Contra Costa Transit Authority**                                    | ✅                 | ✅       | ✅    | \*      |
+| **Yolo County Transportation District**                                       | ✅                 | ✅       | ✅    | \*      |
+| **Yuba-Sutter Transit Authority**                                             | ✅                 | ✅       | ✅    | \*      |
+| **Yurok Tribe)**                                                              | ✅                 | ✅       | ✅    | \*      |
 
 ## Resources
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,17 +15,17 @@ We use this repo to track all requests, questions and new users for the CRM. You
 | [Reporting Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=reporting&template=reporting_request_form.yml&title=%5BReporting+Request%5D%3A+) | Request a new CRM metric and or report. |
 | [Deals Pipeline Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=deals-pipeline&template=deals-pipelines-request-form.yml&title=%5BDeals+Pipeline+Request%5D%3A+) | Request a new deals pipeline in the CRM.
 
-| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt | Technical Support: GTFS |
-| --------------------------------------------------- | -------- | -------- | ----- | ------- | ----------------------- |
-| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      | ✅                     |
-| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*     | \*     | \*                      |
-| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      | \*                      |
+| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt |
+| --------------------------------------------------- | -------- | -------- | ----- | ------- |
+| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      |
+| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      |
+| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      |
+| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      |
+| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      |
+| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      |
+| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      |
+| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      |
+| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      |
+| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      |
+| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*    | \*     |
+| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,18 @@ We use this repo to track all requests, questions and new users for the CRM. You
 | [Question Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=question&template=question-request-form.yml&title=Question%3A+) | Ask a general question about the CRM. |
 | [Reporting Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=reporting&template=reporting_request_form.yml&title=%5BReporting+Request%5D%3A+) | Request a new CRM metric and or report. |
 | [Deals Pipeline Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=deals-pipeline&template=deals-pipelines-request-form.yml&title=%5BDeals+Pipeline+Request%5D%3A+) | Request a new deals pipeline in the CRM.
+
+| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt | Technical Support: GTFS |
+| --------------------------------------------------- | -------- | -------- | ----- | ------- | ----------------------- |
+| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      | ✅                     |
+| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*     | \*     | \*                      |
+| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      | \*                      |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,18 +14,3 @@ We use this repo to track all requests, questions and new users for the CRM. You
 | [Question Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=question&template=question-request-form.yml&title=Question%3A+) | Ask a general question about the CRM. |
 | [Reporting Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=reporting&template=reporting_request_form.yml&title=%5BReporting+Request%5D%3A+) | Request a new CRM metric and or report. |
 | [Deals Pipeline Request Form](https://github.com/cal-itp/customer-success/issues/new?assignees=&labels=deals-pipeline&template=deals-pipelines-request-form.yml&title=%5BDeals+Pipeline+Request%5D%3A+) | Request a new deals pipeline in the CRM.
-
-| Transit provider                                    | Payments | Benefits | Remix | GTFS-rt |
-| --------------------------------------------------- | -------- | -------- | ----- | ------- |
-| **Monterey-Salinas Transit**                        | ✅       | ✅       | ✅    | \*      |
-| **Santa Barbara Metropolitan Transit District**     | ✅       | ✅       | ✅    | \*      |
-| **Sacramento Regional Transit District**            | ✅       | ✅       | ✅    | \*      |
-| **Nevada County Connects**                          | ✅       | ✅       | ✅    | \*      |
-| **Ventura County Transportation Commission**        | ✅       | ✅       | ✅    | \*      |
-| **San Luis Obispo Regional Transit**                | ✅       | ✅       | ✅    | \*      |
-| **El Dorado Transit Authority**                     | ✅       | ✅       | ✅    | \*      |
-| **Redding Area Bus Authority**                      | ✅       | ✅       | ✅    | \*      |
-| **City of San Luis Obispo**                         | ✅       | ✅       | ✅    | \*      |
-| **City of Roseville**                               | ✅       | ✅       | ✅    | \*      |
-| **Santa Cruz Metropolitan Transit District**        | \*       | \*       | \*    | \*     |
-| **Santa Barbara County Association of Governments** | \*       | \*       | \*    | \*      |


### PR DESCRIPTION
Closes #1347 

Draft table that show which agencies are live with which products and when agencies will launch in the future 

TO-DO
- [x] Confirm the list of agencies who are live and who will be live using the [define success metrics](https://docs.google.com/document/d/1nlFzbgXj48Y0tG0JK3HyTfUGyxlKjUyy_maweJHdyYg/edit?tab=t.6te82xkbm1ka) table
- [x] Add more agencies to the list that are missing
- [x] ~~Define Technical support with GTFS and if it needs to be on the list -- REMOVED~~