### PR TITLE
chore: Update vendor activities notebook for Pandas 3 and HubSpot API changes

### DIFF
--- a/notebooks/vendor_activities.ipynb
+++ b/notebooks/vendor_activities.ipynb
@@ -43,6 +43,7 @@
         "from hubspot.crm.associations.v4.models import AssociationSpec, BatchInputPublicAssociationMultiPost, PublicAssociationMultiPost\n",
         "from hubspot.crm.associations.v4.schema.models import PublicAssociationDefinitionCreateRequest\n",
         "\n",
+        "import numpy as np\n",
         "import pandas as pd\n",
         "\n",
         "from data.utils import hubspot_to_df, write_json_records\n",
@@ -137,7 +138,8 @@
         "# look at the unique company types defined\n",
         "if RUN_MODE == RunMode.FULL:\n",
         "    company_types = companies_df[\"properties.company_type\"].unique()\n",
-        "    company_types.tofile(\"data/company_types.txt\", sep=os.linesep)"
+        "    np_array = np.array(list(company_types))\n",
+        "    np_array.tofile(\"data/company_types.txt\", sep=os.linesep)"
       ]
     },
     {
@@ -160,7 +162,7 @@
       "source": [
         "# request vendor properties and read into DataFrame\n",
         "if RUN_MODE == RunMode.FULL:\n",
-        "    vendor_props = hubspot.crm.properties.core_api.get_all(object_type=\"vendors\", archived=False)\n",
+        "    vendor_props = hubspot.crm.properties.core_api.get_all(object_type=\"p5519226_vendors\", archived=False)\n",
         "    vendor_props_df = hubspot_to_df(vendor_props)\n",
         "    write_json_records(vendor_props_df, \"vendor_props.json\")"
       ]
@@ -172,7 +174,7 @@
       "outputs": [],
       "source": [
         "# request vendor data\n",
-        "vendors = hubspot.crm.objects.get_all(\"vendors\", properties=[\"domain\", \"vendor_name\"])\n",
+        "vendors = hubspot.crm.objects.get_all(\"p5519226_vendors\", properties=[\"domain\", \"vendor_name\"])\n",
         "vendors = [v.to_dict() for v in vendors]"
       ]
     },
@@ -215,14 +217,14 @@
         "    # association definitions for the vendor custom object\n",
         "    # i.e. vendors --> emails\n",
         "    #      vendors --> meetings\n",
-        "    fwd = hubspot.crm.associations.v4.schema.definitions_api.get_all(\"vendors\", association_type)\n",
+        "    fwd = hubspot.crm.associations.v4.schema.definitions_api.get_all(\"p5519226_vendors\", association_type)\n",
         "    dff = hubspot_to_df(fwd)\n",
         "    dff[\"type\"] = association_type\n",
         "    dff[\"dir\"] = \"forward\"\n",
         "    # reverse association definitions for the vendor custom object\n",
         "    # i.e. emails --> vendors\n",
         "    #      meetings --> vendors\n",
-        "    rev = hubspot.crm.associations.v4.schema.definitions_api.get_all(association_type, \"vendors\")\n",
+        "    rev = hubspot.crm.associations.v4.schema.definitions_api.get_all(association_type, \"p5519226_vendors\")\n",
         "    dfr = hubspot_to_df(rev)\n",
         "    dfr[\"type\"] = association_type\n",
         "    dfr[\"dir\"] = \"reverse\"\n",
@@ -569,7 +571,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.6"
+      "version": "3.11.15"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
- DataFrame.Series.unique() no longer returns a NumPy array, so make it one manually.
- Custom object types must now be referred to by their `fullyQualifiedName`