### PR TITLE
update product table

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,39 +44,58 @@ Last updated: `3/09/2026`
 | Transit provider                                                              | Open loop payments       | Cal-ITP Benefits | Remix          | GTFS-RT        |
 | ----------------------------------------------------------------------------- | ------------------------ | ---------------- | -------------- | -------------- |
 | **Alameda-Contra Costa Transit District (AC Transit)**                        | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
+| **Antelope Valley Transit Authority**                                         | ✅ `non-MSA` _(Q2 2026)_ | ❌               | \-             | \-             |
+| **Arvin Transit (City of Arvin)**                                             | \-                       | \-               | ✅ _(Q2 2025)_ | \-             |
 | **Butte County Association of Governments/ Butte Regional Transit**           | Q4 2026                  | Q4 2026          | \-             | \-             |
 | **Calaveras Transit Agency**                                                  | \-                       | \-               | \-             | \-             |
 | **Caltrain**                                                                  | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
-| **Capitol Corridor Joint Powers Authority (CCJPA)**                           | ✅ _(Q2 2023)_           | \-               | \-             | \-             |
+| **Capitol Corridor Joint Powers Authority (CCJPA)**                           | ✅ `non-MSA` _(Q2 2023)_ | \-               | \-             | \-             |
 | **Central Contra Costa Transit Authority (County Connection)**                | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
-| **City and County of San Francisco**                                          | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
-| **City of Arvin**                                                             | \-                       | \-               | ✅ _(Q2 2025)_ | \-             |
+| **City of Baldwin Park**                                                      | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Burbank**                                                           | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Camarillo**                                                         | ✅ _(Q1 2026)_           | Q3 2026          | \-             | \-             |
+| **City of Carson**                                                            | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Compton**                                                           | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Culver City**                                                       | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Escalon**                                                           | \-                       | \-               | ✅ _(Q1 2025)_ | \-             |
-| **City of Fairfield**                                                         | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
-| **City of Glendale**                                                          | Q4 2026                  | \-               | \-             | Q4 2026        |
-| **City of Lathrop**                                                           | \-                       | \-               | Q2 2026        | \-             |
+| **City of Fairfield**                                                         | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
+| **City of Gardena**                                                           | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Glendale**                                                          | Q4 2026                  | ❌               | \-             | Q4 2026        |
+| **City of Glendora**                                                          | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Huntington Park**                                                   | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Lathrop**                                                           | \-                       | \-               | ✅ _(Q2 2026)_ | \-             |
+| **City of Lawndale**                                                          | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Montebello**                                                        | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **City of Monterey Park**                                                     | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Moorpark**                                                          | Q2 2026                  | ❌               | \-             | \-             |
 | **City of Morro Bay**                                                         | ✅ _(Q2 2026)_           | ✅ _(Q4 2025)_   | \-             | \-             |
+| **City of Norwalk**                                                           | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Ojai**                                                              | Q2 2026                  | Q3 2026          | \-             | \-             |
+| **City of Pasadena**                                                          | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Petaluma**                                                          | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
+| **City of Redondo Beach**                                                     | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Roseville**                                                         | Q2 2026                  | Q2 2026          | \-             | \-             |
 | **City of San Luis Obispo**                                                   | ✅ _(Q2 2026)_           | ✅ _(Q2 2026)_   | \-             | \-             |
+| **City of Santa Clarita**                                                     | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Santa Maria**                                                       | \-                       | \-               | ✅ _(Q1 2025)_ | \-             |
+| **City of Santa Monica**                                                      | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Santa Rosa**                                                        | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
 | **City of Simi Valley**                                                       | Q3 2026                  | Q3 2026          | \-             | \-             |
 | **City of Thousand Oaks**                                                     | Q2 2026                  | Q3 2026          | \-             | \-             |
+| **City of Torrance (Torrance Transit)**                                       | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **City of Union City**                                                        | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **City of Vacaville**                                                         | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **City of Wasco**                                                             | 2026                     | 2026             | \-             | \-             |
 | **Cloverdale Transit**                                                        | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **County of Kern**                                                            | \-                       | \-               | ✅ _(Q1 2025)_ | \-             |
-| **County of Los Angeles - Department of Public Works**                        | \-                       | \-               | 2026           | \-             |
+| **County of Los Angeles - Department of Public Works**                        | ✅ _(Q2 2026)_           | ❌               | 2026           | \-             |
 | **County of Nevada**                                                          | ✅ _(Q2 2025)_           | ✅ _(Q1 2025)_   | ✅ _(Q1 2025)_ | \-             |
-| **County of Sacramento (SCT Link)**                                           | Q3 2026                  | Q3 2026          | ✅ _(Q1 2025)_ | 2026             |
+| **Dumbarton Bridge Regional Operations Consortium**                           | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **County of Sacramento (SCT Link)**                                           | Q3 2026                  | Q3 2026          | ✅ _(Q1 2025)_ | 2026           |
 | **Eastern Contra Costa Transit Authority**                                    | ✅ `non-MSA` _(Q4 2025)_ | ❌               | ✅ _(Q1 2026)_ | \-             |
 | **Eastern Sierra Transit Authority**                                          | \-                       | \-               | Q2 2026         | \-            |
 | **El Dorado Transit Authority**                                               | ✅ _(Q1 2026)_           | ✅ _(Q1 2026)_   | Q2 2026        | 2026           |
+| **Foothill Transit**                                                          | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **Glenn County Transportation Commission**                                    | Q2 2026                  | \-               | ✅ _(Q4 2025)_ | \-             |
 | **Gold Coast Transit District**                                               | Q2 2026                  | Q3 2026          | \-             | \-             |
 | **Golden Empire Transit District**                                            | Q4 2026                  | Q4 2026          | \-             | \-             |
@@ -84,25 +103,33 @@ Last updated: `3/09/2026`
 | **Humboldt Transit Authority**                                                | ✅ _(Q1 2023)_           | ❌               | ✅ _(Q1 2025)_ | \-             |
 | **Imperial County Transportation Commission**                                 | Q4 2026                  | Q4 2026          | \-             | Q2 2026        |
 | **Kings County Area Public Transit Agency**                                   | \-                       | \-               | ✅ _(Q1 2026)_ | \-             |
+| **LADOT**                                                                     | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **Lake Transit Authority**                                                    | ✅ _(Q1 2023)_           | \-               | ✅ _(Q1 2025)_ | \-             |
 | **Lassen Transit Service Agency**                                             | \-                       | \-               | ✅ _(Q2 2025)_ | \-             |
 | **Livermore Amador Valley Transit Authority**                                 | ✅ `non-MSA` _(Q4 2025)_ | ❌               | ✅ _(Q4 2025)_ | \-             |
+| **Long Beach Transit**                                                        | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **Los Angeles Metropolitan Transportation Authority**                         | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
+| **Los Angeles World Airports**                                                | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **Madera County**                                                             | Q4 2026                  | Q4 2026          | \-             | \-             |
 | **Marin Transit**                                                             | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **Mendocino Transit Authority**                                               | ✅ _(Q1 2023)_           | \-               | ✅ _(Q1 2025)_ | \-             |
-| **Metrolink**                                                                 | 2026                     | \-               | \-             | 2026           |
 | **Monterey-Salinas Transit**                                                  | ✅ _(Q3 2023)_           | ✅ _(Q4 2021)_   | ✅ _(Q1 2026)_ | \-             |
+| **Mountain Transit (MARTA)**                                                  | \-                       | \-               | ✅ _(Q1 2025)_ | \-             |
 | **Napa Valley Transportation Authority (NVTA)**                               | ✅ `non-MSA` _(Q4 2025)_ | ❌               | ✅ _(Q1 2026)_ | \-             |
 | **North County Transit District (NCTD)**                                      | ✅ `non-MSA` _(Q3 2024)_ | ❌               | \-             | \-             |
 | **Orange County Transportation Authority**                                    | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
+| **Palos Verdes Peninsula Transit Authority**                                  | ✅ `non-MSA` _(Q2 2026)_ | ❌               | \-             | \-             |
+| **Peninsula Corridor Joint Powers Board (Caltrain)**                          | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
 | **Placer County**                                                             | \-                       | \-               | 2026           | \-             |
 | **Redding Area Bus Authority**                                                | ✅ _(Q1 2026)_           | ✅ _(Q1 2026)_   | ✅ _(Q1 2025)_ | \-             |
 | **Redwood Coast Transit Authority**                                           | ✅ _(Q1 2023)_           | ❌               | ✅ _(Q1 2025)_ | \-             |
+| **Sacramento County (SCT Link / South County Transit)**                       | Q3 2026                  | Q3 2026          | ✅ _(Q1 2025)_ | 2026           |
 | **Sacramento Regional Transit District (SacRT)**                              | ✅ _(Q1 2025)_           | ✅ _(Q4 2024)_   | \-             | \-             |
 | **San Benito County Local Transportation Authority**                          | \-                       | \-               | ✅ _(Q1 2025)_ | \-             |
 | **San Diego Metropolitan Transit System (MTS)**                               | ✅ `non-MSA` _(Q3 2024)_ | ❌               | \-             | \-             |
 | **San Francisco Bay Area Rapid Transit District (BART)**                      | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **San Francisco Bay Area Water Emergency Transportation Authority (WETA)**    | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
+| **San Francisco MTA (City and County of San Francisco)**                      | ✅ `non-MSA` _(Q4 2024)_ | ❌               | \-             | \-             |
 | **San Luis Obispo Regional Transit Authority**                                | ✅ _(Q2 2026)_           | ✅ _(Q4 2025)_   | \-             | \-             |
 | **San Mateo County Transit District**                                         | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **Santa Barbara County Association of Governments (SBCAG)**                   | ✅ _(Q1 2023)_           | Q3 2026          | ✅ _(Q1 2025)_ | \-             |
@@ -113,6 +140,7 @@ Last updated: `3/09/2026`
 | **Solano County Transit (SolTrans)**                                          | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
 | **Sonoma County Transit (SC Transit)**                                        | ✅ `non-MSA` _(Q4 2025)_ | ❌               | ✅ _(Q1 2026)_ | \-             |
 | **Sonoma-Marin Area Rail Transit**                                            | ✅ `non-MSA` _(Q4 2025)_ | ❌               | \-             | \-             |
+| **Southern California Regional Rail Authority (SCRRA Metrolink)**             | ✅ _(Q2 2026)_           | ❌               | \-             | \-             |
 | **Stanislaus Regional Transit Authority**                                     | Q4 2026                  | Q4 2026          | ✅ _(Q1 2026)_ | \-             |
 | **Sunline Transit Agency**                                                    | Q4 2026                  | Q4 2026          | ✅ _(Q1 2026)_ | \-             |
 | **Transit Joint Powers Authority for Merced County**                          | \-                       | \-               | ✅ _(Q2 2025)_ | \-             |


### PR DESCRIPTION
Closes #1568 

Update live status for LA Metro agencies, and adds new Los Angeles agencies that weren't on the product table.