### PR TITLE
Fix issue setting up Python in HubSpot export workflow

### DIFF
--- a/.github/workflows/export-hubspot-data.yml
+++ b/.github/workflows/export-hubspot-data.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - parallel:
-        - name: Check out code
-          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # 7.0.0
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # 7.0.0
 
+      - parallel:
         - name: Set up Python
           uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # 6.3.0
           with:


### PR DESCRIPTION
I thought it wouldn't matter until the `pip install` step, but I guess you gotta check out before setup-python can accept a `cache-dependency-path` option.