### PR TITLE
Add notebook for exporting Benefits newsletters

### DIFF
--- a/notebooks/benefits_emails.ipynb
+++ b/notebooks/benefits_emails.ipynb
@@ -1,0 +1,136 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Introduction\n",
+        "\n",
+        "This notebook retrieves the web version of Benefits product newsletters from HubSpot's archive and stores them for later publication on the Benefits docs site."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Setup\n",
+        "\n",
+        "Requires a HubSpot [legacy private app](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview) with the `content` scope.\n",
+        "\n",
+        "The app will provide an access token that should be stored in an environment variable called `HUBSPOT_ACCESS_TOKEN`.\n",
+        "\n",
+        "You can copy the sample environment file to get started; run the following command from the root of this repository:\n",
+        "\n",
+        "```bash\n",
+        "cp .env.sample .env\n",
+        "```\n",
+        "\n",
+        "Then open `.env` and fill in with your access token.\n",
+        "\n",
+        "**The block below should be run before attempting any other blocks in this notebook.**\n",
+        "It will need to be re-run after restarting the kernel, as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import urllib\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import requests\n",
+        "from bs4 import BeautifulSoup\n",
+        "from hubspot import HubSpot\n",
+        "\n",
+        "from data.utils import hubspot_get_all_pages, hubspot_to_df\n",
+        "\n",
+        "\n",
+        "ACCESS_TOKEN = os.environ[\"HUBSPOT_ACCESS_TOKEN\"]\n",
+        "PAGE_SIZE = int(os.environ.get(\"HUBSPOT_PAGE_SIZE\", 10))\n",
+        "\n",
+        "hubspot = HubSpot(access_token=ACCESS_TOKEN)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Export"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# retrieve all emails\n",
+        "emails_response = hubspot_get_all_pages(\n",
+        "    hubspot.marketing.emails.marketing_emails_api,\n",
+        "    page_size=PAGE_SIZE,\n",
+        "    included_properties=[\"publishDate\", \"subject\", \"subscriptionDetails\", \"webversion\"],\n",
+        "    sort=[\"updated_at\"],\n",
+        ")\n",
+        "emails_df = hubspot_to_df(emails_response)\n",
+        "\n",
+        "# filter down to emails sent to Benefits Product Updates subscribers\n",
+        "emails_df_benefits = emails_df[emails_df[\"subscription_details.subscription_id\"].eq(\"313573410\")]\n",
+        "\n",
+        "# loop through emails\n",
+        "for row_index, row in emails_df_benefits.iterrows():\n",
+        "    # scrape HTML\n",
+        "    r = requests.get(row['webversion.url'])\n",
+        "    soup = BeautifulSoup(r.content, \"html.parser\")\n",
+        "\n",
+        "    # collect images and store in shared images folder (overwriting any with same filename)\n",
+        "    for img in soup.find_all(\"img\"):\n",
+        "        img_src = img[\"src\"]\n",
+        "        img_src_parsed = urllib.parse.urlsplit(img_src)\n",
+        "        filename = os.path.basename(img_src_parsed.path)\n",
+        "\n",
+        "        # download image if we haven't yet\n",
+        "        decoded_filename = urllib.parse.unquote(filename)\n",
+        "        download_path = f\"benefits_emails/images/{decoded_filename}\"\n",
+        "        if not Path(download_path).exists():\n",
+        "            print(f\"Downloading {decoded_filename} from {img_src_parsed._replace(query='').geturl()}\")\n",
+        "            with open(download_path, mode=\"wb\") as file:\n",
+        "                img_r = requests.get(img_src_parsed._replace(query=\"\").geturl())  # drop query params to get largest size\n",
+        "                file.write(img_r.content)\n",
+        "\n",
+        "        # replace original src with relative path and drop responsive attrs\n",
+        "        img[\"src\"] = f\"images/{filename}\"\n",
+        "        del img[\"sizes\"]\n",
+        "        del img[\"srcset\"]\n",
+        "\n",
+        "    # write the updated HTML to a file named with the sending date\n",
+        "    send_time = row[\"publish_date\"].tz_convert(\"America/Los_Angeles\")\n",
+        "    with open(f\"benefits_emails/{send_time.strftime('%Y-%m-%d')}.html\", \"w\") as file:\n",
+        "        file.write(str(soup))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.15"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/notebooks/full_export.ipynb
+++ b/notebooks/full_export.ipynb
@@ -35,7 +35,7 @@
       "source": [
         "### Setup\n",
         "\n",
-        "Requires a HubSpot [legacy private app](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview) with every available scope ending in `.read`.\n",
+        "Requires a HubSpot [legacy private app](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview) with every available scope ending in `.read`, and some others noted in the comments.\n",
         "\n",
         "The app will provide an access token that should be stored in an environment variable called `HUBSPOT_ACCESS_TOKEN`.\n",
         "\n",

--- a/notebooks/properties.ipynb
+++ b/notebooks/properties.ipynb
@@ -26,7 +26,7 @@
       "source": [
         "### Setup\n",
         "\n",
-        "Requires a HubSpot [legacy private app](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview) with every available scope ending in `.read`.\n",
+        "Requires a HubSpot [legacy private app](https://developers.hubspot.com/docs/apps/legacy-apps/private-apps/overview) with [a scope that allows accessing the Properties API](https://developers.hubspot.com/docs/api-reference/legacy/crm/properties/guide#scope-requirements).\n",
         "\n",
         "The app will provide an access token that should be stored in an environment variable called `HUBSPOT_ACCESS_TOKEN`.\n",
         "\n",


### PR DESCRIPTION
Closes #1717

---

This adds a notebook that will fetch all marketing emails sent to the Benefits Product Updates list and save their web version's rendered HTML. It fetches all images that are used and saves those in a shared images folder, then updates the `img` elements' `src` attributes to point to those with relative paths.